### PR TITLE
Fixed error thrown when converting collapsed range

### DIFF
--- a/src/change-case-commands.ts
+++ b/src/change-case-commands.ts
@@ -147,7 +147,7 @@ function getSelectedText(selection: vscode.Selection, document: vscode.TextDocum
     }
 
     return {
-        text: range ? document.getText(range) : undefined,
+        text: range ? document.getText(range) : '',
         range
     };
 }
@@ -164,7 +164,9 @@ function getChangeCaseWordRangeAtPosition(document: vscode.TextDocument, positio
         : CHANGE_CASE_WORD_CHARACTER_REGEX_WITHOUT_DOT;
 
     const range = document.getWordRangeAtPosition(position);
-    if (!range) return undefined;
+
+    // If can't locate return a collapsed range (#13).
+    if (!range) return new vscode.Range(position, position);
 
     let startCharacterIndex = range.start.character - 1;
     while (startCharacterIndex >= 0) {


### PR DESCRIPTION
The problem was caused by [returning undefined instead of range](https://github.com/wmaurer/vscode-change-case/blob/7e1f0e1/src/change-case-commands.ts#L167) instance when VSCode couldn't pick any word at given position.

Change in [text returned in getSelectedText](https://github.com/mlewand/vscode-change-case/blob/0e56d649079afc528ba1c591fd96721b703e84bf/src/change-case-commands.ts#L150) when there is no range is not necessary for this fix, but it will make the code more bulletproof in future.

As mentioned in #13 it looks also to fix #12, although I might be missing something in terms of error reproduction.

And by the way, thanks for nice extension! Definitely saved me some time.